### PR TITLE
New sandbox actions

### DIFF
--- a/sfcc-build/assure-sandbox-up/action.yml
+++ b/sfcc-build/assure-sandbox-up/action.yml
@@ -39,9 +39,11 @@ runs:
 
         if [ "$STATE" = "started" ]; then
           echo "Sandbox is up and running."
+          echo "Finish time: $(date +"%Y-%m-%dT%H:%M:%S")"
           EXIT_CODE=0
         else
-          echo "Sandbox did not start within the time limit."
+          echo "ERR: Sandbox did not start within the time limit."
+          echo "Finish time: $(date +"%Y-%m-%dT%H:%M:%S")"
           EXIT_CODE=1
         fi
 

--- a/sfcc-build/assure-sandbox-up/action.yml
+++ b/sfcc-build/assure-sandbox-up/action.yml
@@ -24,16 +24,17 @@ runs:
           --header "Authorization: Bearer $2"
         }
 
+        SECONDS=0
         END_TIME=$((SECONDS + ${{ inputs.TIMEOUT }}))
         RESPONSE=$(api ${{ inputs.SANDBOX_ID }} ${{ inputs.SFCC_TOKEN }})
         STATE=$(echo $RESPONSE | jq -r '.data.state')
-        echo $RESPONSE
+        echo -e "API call sent: $(date +"%Y-%m-%dT%H:%M:%S")\n$RESPONSE"
 
-        while [ $SECONDS -lt $END_TIME ] || [ "$STATE" != "started" ]; do
+        while [ $SECONDS -lt $END_TIME ] && [ "$STATE" != "started" ]; do
           sleep 30
           RESPONSE=$(api ${{ inputs.SANDBOX_ID }} ${{ inputs.SFCC_TOKEN }})
           STATE=$(echo $RESPONSE | jq -r '.data.state')
-          echo $RESPONSE
+          echo -e "API call sent: $(date +"%Y-%m-%dT%H:%M:%S")\n$RESPONSE"
         done
 
         if [ "$STATE" = "started" ]; then

--- a/sfcc-build/assure-sandbox-up/action.yml
+++ b/sfcc-build/assure-sandbox-up/action.yml
@@ -1,0 +1,26 @@
+name: 'assure-sandbox-up'
+description: 'Makes sure the sandbox is in started state'
+author: 'Seidor'
+inputs:
+  SANDBOX_ID:
+    description: 'Sandbox ID'
+    required: true
+  SFCC_TOKEN:
+    description: 'Token used for authentication in api calls'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: 'assure-sandbox-up'
+      shell: bash -e {0}
+      run: |
+        STATE=""
+        while [ "$STATE" != "started" ]; do
+          RESPONSE=$(curl --location "https://admin.dx.commercecloud.salesforce.com/api/v1/sandboxes/${{ inputs.SANDBOX_ID }}" \
+          --header "accept: application/json" \
+          --header "Authorization: Bearer ${{ inputs.SFCC_TOKEN }}")
+          STATE=$(echo $RESPONSE | jq -r '.data.state')
+          sleep 30
+        done
+        echo $RESPONSE

--- a/sfcc-build/assure-sandbox-up/action.yml
+++ b/sfcc-build/assure-sandbox-up/action.yml
@@ -8,6 +8,9 @@ inputs:
   SFCC_TOKEN:
     description: 'Token used for authentication in api calls'
     required: true
+  TIMEOUT:
+    description: 'Timeout in seconds'
+    default: '300'
 
 runs:
   using: composite
@@ -16,11 +19,23 @@ runs:
       shell: bash -e {0}
       run: |
         STATE=""
-        while [ "$STATE" != "started" ]; do
+        END_TIME=$((SECONDS + ${{ inputs.TIMEOUT }}))
+
+        while [ $SECONDS -lt $END_TIME ]; do
           RESPONSE=$(curl --location "https://admin.dx.commercecloud.salesforce.com/api/v1/sandboxes/${{ inputs.SANDBOX_ID }}" \
           --header "accept: application/json" \
           --header "Authorization: Bearer ${{ inputs.SFCC_TOKEN }}")
+
+          echo $RESPONSE
           STATE=$(echo $RESPONSE | jq -r '.data.state')
-          if [ "$STATE" != "started" ]; then sleep 30; fi
+
+          if [ "$STATE" == "started" ]; then
+            echo "Sandbox is in started state."
+            exit 0
+          fi
+
+          sleep 30
         done
-        echo $RESPONSE
+
+        echo "Sandbox did not start within the time limit."
+        exit 1

--- a/sfcc-build/assure-sandbox-up/action.yml
+++ b/sfcc-build/assure-sandbox-up/action.yml
@@ -18,24 +18,30 @@ runs:
     - name: 'assure-sandbox-up'
       shell: bash -e {0}
       run: |
-        STATE=""
-        END_TIME=$((SECONDS + ${{ inputs.TIMEOUT }}))
-
-        while [ $SECONDS -lt $END_TIME ]; do
-          RESPONSE=$(curl --location "https://admin.dx.commercecloud.salesforce.com/api/v1/sandboxes/${{ inputs.SANDBOX_ID }}" \
+        api() {
+          curl --location "https://admin.dx.commercecloud.salesforce.com/api/v1/sandboxes/${1}" \
           --header "accept: application/json" \
-          --header "Authorization: Bearer ${{ inputs.SFCC_TOKEN }}")
+          --header "Authorization: Bearer $2"
+        }
 
-          echo $RESPONSE
-          STATE=$(echo $RESPONSE | jq -r '.data.state')
+        END_TIME=$((SECONDS + ${{ inputs.TIMEOUT }}))
+        RESPONSE=$(api ${{ inputs.SANDBOX_ID }} ${{ inputs.SFCC_TOKEN }})
+        STATE=$(echo $RESPONSE | jq -r '.data.state')
+        echo $RESPONSE
 
-          if [ "$STATE" == "started" ]; then
-            echo "Sandbox is in started state."
-            exit 0
-          fi
-
+        while [ $SECONDS -lt $END_TIME ] || [ "$STATE" != "started" ]; do
           sleep 30
+          RESPONSE=$(api ${{ inputs.SANDBOX_ID }} ${{ inputs.SFCC_TOKEN }})
+          STATE=$(echo $RESPONSE | jq -r '.data.state')
+          echo $RESPONSE
         done
 
-        echo "Sandbox did not start within the time limit."
-        exit 1
+        if [ "$STATE" = "started" ]; then
+          echo "Sandbox is up and running."
+          EXIT_CODE=0
+        else
+          echo "Sandbox did not start within the time limit."
+          EXIT_CODE=1
+        fi
+
+        exit $EXIT_CODE

--- a/sfcc-build/assure-sandbox-up/action.yml
+++ b/sfcc-build/assure-sandbox-up/action.yml
@@ -21,6 +21,6 @@ runs:
           --header "accept: application/json" \
           --header "Authorization: Bearer ${{ inputs.SFCC_TOKEN }}")
           STATE=$(echo $RESPONSE | jq -r '.data.state')
-          sleep 30
+          if [ "$STATE" != "started" ]; then sleep 30; fi
         done
         echo $RESPONSE

--- a/sfcc-build/auth-and-set-default-instance/action.yml
+++ b/sfcc-build/auth-and-set-default-instance/action.yml
@@ -17,13 +17,24 @@ inputs:
   SET_DEFAULT_INSTANCE:
     description: 'Whether or not to set instance as default'
     default: 'false'
+outputs:
+  SFCC_TOKEN:
+    description: 'Token used for authentication in api calls'
+    value: ${{ steps.one.outputs.SFCC_TOKEN }}
 
 runs:
   using: composite
   steps:
     - name: 'Authenticate and set default instance'
+      id: 'one'
       shell: bash -el {0}
       run: |
+        TOOLS_FOLDER="$GITHUB_WORKSPACE/${{ inputs.TOOLS_FOLDER }}"
         ADD_DEFAULT_INSTANCE=$([ "${{ inputs.SET_DEFAULT_INSTANCE }}" = "true" ] && echo "-d" || echo "")
-        node "${{ inputs.TOOLS_FOLDER }}/node_modules/sfcc-ci/cli.js" "client:auth" ${{ inputs.CLIENT_ID }} ${{ inputs.CLIENT_SECRET }}
-        node "${{ inputs.TOOLS_FOLDER }}/node_modules/sfcc-ci/cli.js" "instance:add" ${{ inputs.INSTANCE_URL }} ${ADD_DEFAULT_INSTANCE}
+        node "$TOOLS_FOLDER/node_modules/sfcc-ci/cli.js" "client:auth" ${{ inputs.CLIENT_ID }} ${{ inputs.CLIENT_SECRET }}
+
+        #node "$TOOLS_FOLDER/node_modules/sfcc-ci/cli.js" "instance:add" ${{ inputs.INSTANCE_URL }} ${ADD_DEFAULT_INSTANCE}
+        echo "node \"$TOOLS_FOLDER/node_modules/sfcc-ci/cli.js\" \"instance:add\" ${{ inputs.INSTANCE_URL }} ${ADD_DEFAULT_INSTANCE}"
+        
+        TOKEN=$(node "$TOOLS_FOLDER/node_modules/sfcc-ci/cli.js" "client:auth:token")
+        echo "SFCC_TOKEN=$TOKEN" >> $GITHUB_OUTPUT

--- a/sfcc-build/auth-and-set-default-instance/action.yml
+++ b/sfcc-build/auth-and-set-default-instance/action.yml
@@ -37,5 +37,5 @@ runs:
         TOKEN=$(node "$TOOLS_FOLDER/node_modules/sfcc-ci/cli.js" "client:auth:token")
         echo "SFCC_TOKEN=$TOKEN" >> $GITHUB_OUTPUT
 
-        #node "$TOOLS_FOLDER/node_modules/sfcc-ci/cli.js" "instance:add" ${{ inputs.INSTANCE_URL }} ${ADD_DEFAULT_INSTANCE}
-        echo "node \"$TOOLS_FOLDER/node_modules/sfcc-ci/cli.js\" \"instance:add\" ${{ inputs.INSTANCE_URL }} ${ADD_DEFAULT_INSTANCE}"
+        node "$TOOLS_FOLDER/node_modules/sfcc-ci/cli.js" "instance:add" ${{ inputs.INSTANCE_URL }} ${ADD_DEFAULT_INSTANCE}
+        #echo "node \"$TOOLS_FOLDER/node_modules/sfcc-ci/cli.js\" \"instance:add\" ${{ inputs.INSTANCE_URL }} ${ADD_DEFAULT_INSTANCE}"

--- a/sfcc-build/auth-and-set-default-instance/action.yml
+++ b/sfcc-build/auth-and-set-default-instance/action.yml
@@ -20,13 +20,13 @@ inputs:
 outputs:
   SFCC_TOKEN:
     description: 'Token used for authentication in api calls'
-    value: ${{ steps.one.outputs.SFCC_TOKEN }}
+    value: ${{ steps.token.outputs.SFCC_TOKEN }}
 
 runs:
   using: composite
   steps:
     - name: 'Authenticate and set default instance'
-      id: 'one'
+      id: 'token'
       shell: bash -el {0}
       run: |
         TOOLS_FOLDER="$GITHUB_WORKSPACE/${{ inputs.TOOLS_FOLDER }}"
@@ -38,4 +38,3 @@ runs:
         echo "SFCC_TOKEN=$TOKEN" >> $GITHUB_OUTPUT
 
         node "$TOOLS_FOLDER/node_modules/sfcc-ci/cli.js" "instance:add" ${{ inputs.INSTANCE_URL }} ${ADD_DEFAULT_INSTANCE}
-        #echo "node \"$TOOLS_FOLDER/node_modules/sfcc-ci/cli.js\" \"instance:add\" ${{ inputs.INSTANCE_URL }} ${ADD_DEFAULT_INSTANCE}"

--- a/sfcc-build/auth-and-set-default-instance/action.yml
+++ b/sfcc-build/auth-and-set-default-instance/action.yml
@@ -31,10 +31,11 @@ runs:
       run: |
         TOOLS_FOLDER="$GITHUB_WORKSPACE/${{ inputs.TOOLS_FOLDER }}"
         ADD_DEFAULT_INSTANCE=$([ "${{ inputs.SET_DEFAULT_INSTANCE }}" = "true" ] && echo "-d" || echo "")
+        TOKEN=""
+        
         node "$TOOLS_FOLDER/node_modules/sfcc-ci/cli.js" "client:auth" ${{ inputs.CLIENT_ID }} ${{ inputs.CLIENT_SECRET }}
+        TOKEN=$(node "$TOOLS_FOLDER/node_modules/sfcc-ci/cli.js" "client:auth:token")
+        echo "SFCC_TOKEN=$TOKEN" >> $GITHUB_OUTPUT
 
         #node "$TOOLS_FOLDER/node_modules/sfcc-ci/cli.js" "instance:add" ${{ inputs.INSTANCE_URL }} ${ADD_DEFAULT_INSTANCE}
         echo "node \"$TOOLS_FOLDER/node_modules/sfcc-ci/cli.js\" \"instance:add\" ${{ inputs.INSTANCE_URL }} ${ADD_DEFAULT_INSTANCE}"
-        
-        TOKEN=$(node "$TOOLS_FOLDER/node_modules/sfcc-ci/cli.js" "client:auth:token")
-        echo "SFCC_TOKEN=$TOKEN" >> $GITHUB_OUTPUT

--- a/sfcc-build/compile-statics/action.yml
+++ b/sfcc-build/compile-statics/action.yml
@@ -12,14 +12,15 @@ runs:
     - name: 'Compile Statics'
       shell: bash -el {0}
       run: |
-        for VERSION in $(yq e '.node_version | keys | .[]' "${{ inputs.CFG_FILE }}"); do
+        CFG_FILE="$GITHUB_WORKSPACE/${{ inputs.CFG_FILE }}"
+        for VERSION in $(yq e '.node_version | keys | .[]' "$CFG_FILE"); do
           node -v && nvm use $VERSION && node -v
           echo "Compiling statics for version $VERSION:"
-          for CARTRIDGE in $(yq e '.node_version."'"$VERSION"'" | keys | .[]' "${{ inputs.CFG_FILE }}"); do
-            FOLDER=$(yq e '.node_version."'"$VERSION"'"."'"$CARTRIDGE"'".path' "${{ inputs.CFG_FILE }}")
+          for CARTRIDGE in $(yq e '.node_version."'"$VERSION"'" | keys | .[]' "$CFG_FILE"); do
+            FOLDER=$(yq e '.node_version."'"$VERSION"'"."'"$CARTRIDGE"'".path' "$CFG_FILE")
             cd "$GITHUB_WORKSPACE/$FOLDER"
             echo "Compiling statics for cartridge $CARTRIDGE:"
-            yq e '.node_version."'"$VERSION"'"."'"$CARTRIDGE"'".compilation | .[]' "${{ inputs.CFG_FILE }}" | xargs -I {} bash -e -c "{}"
+            yq e '.node_version."'"$VERSION"'"."'"$CARTRIDGE"'".compilation | .[]' "$CFG_FILE" | xargs -I {} bash -e -c "{}"
             echo "Statics for cartridge $CARTRIDGE have been compiled"
           done
         done

--- a/sfcc-build/install-node-modules/action.yml
+++ b/sfcc-build/install-node-modules/action.yml
@@ -12,11 +12,12 @@ runs:
     - name: 'install node modules'
       shell: bash -el {0}
       run: |
-        for VERSION in $(yq e '.node_version | keys | .[]' "${{ inputs.CFG_FILE }}"); do
+        CFG_FILE="$GITHUB_WORKSPACE/${{ inputs.CFG_FILE }}"
+        for VERSION in $(yq e '.node_version | keys | .[]' "$CFG_FILE"); do
           node -v && nvm use $VERSION && node -v
           echo "Installing cartridges for version $VERSION:"
-          for CARTRIDGE in $(yq e '.node_version."'"$VERSION"'" | keys | .[]' "${{ inputs.CFG_FILE }}"); do
-            FOLDER=$(yq e '.node_version."'"$VERSION"'"."'"$CARTRIDGE"'".path' "${{ inputs.CFG_FILE }}")
+          for CARTRIDGE in $(yq e '.node_version."'"$VERSION"'" | keys | .[]' "$CFG_FILE"); do
+            FOLDER=$(yq e '.node_version."'"$VERSION"'"."'"$CARTRIDGE"'".path' "$CFG_FILE")
             cd "$GITHUB_WORKSPACE/$FOLDER"
             npm install
             echo "$CARTRIDGE installed"

--- a/sfcc-build/install-nvm/action.yml
+++ b/sfcc-build/install-nvm/action.yml
@@ -12,8 +12,9 @@ runs:
     - name: 'install nvm & node'
       shell: bash -e {0}
       run: |
+        CFG_FILE="$GITHUB_WORKSPACE/${{ inputs.CFG_FILE }}"
         curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash -e
         cat ~/.bashrc
         source $HOME/.nvm/nvm.sh
-        for VERSION in $(yq e '.node_version | keys | .[]' "${{ inputs.CFG_FILE }}"); do nvm install $VERSION; done
+        for VERSION in $(yq e '.node_version | keys | .[]' "$CFG_FILE"); do nvm install $VERSION; done
         nvm ls --no-alias && nvm use $VERSION && node -v && nvm -v

--- a/sfcc-build/install-tools/action.yml
+++ b/sfcc-build/install-tools/action.yml
@@ -12,6 +12,7 @@ runs:
     - name: 'install tools'
       shell: bash -el {0}
       run: |
+        TOOLS_FOLDER="$GITHUB_WORKSPACE/${{ inputs.TOOLS_FOLDER }}"
         VERSION=$(nvm ls --no-alias | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' | tail -n1)
         node -v && nvm use $VERSION && node -v
-        cd "${{ inputs.TOOLS_FOLDER }}" && npm install sfcc-ci && cd "$GITHUB_WORKSPACE"
+        cd "$TOOLS_FOLDER" && npm install sfcc-ci && cd "$GITHUB_WORKSPACE"

--- a/sfcc-build/start-sandbox/action.yml
+++ b/sfcc-build/start-sandbox/action.yml
@@ -1,0 +1,24 @@
+name: 'start-sandbox'
+description: 'Starts sandbox'
+author: 'Seidor'
+inputs:
+  SANDBOX_ID:
+    description: 'Sandbox ID'
+    required: true
+  SFCC_TOKEN:
+    description: 'Token used for authentication in api calls'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: 'start-sandbox'
+      shell: bash -e {0}
+      run: |
+        curl --location "https://admin.dx.commercecloud.salesforce.com/api/v1/sandboxes/${{ inputs.SANDBOX_ID }}/operations" \
+        --header "Accept: application/json" \
+        --header "Content-Type: application/json" \
+        --header "Authorization: Bearer ${{ inputs.SFCC_TOKEN }}" \
+        --data '{
+        "operation": "start"
+        }'

--- a/sfcc-build/stop-sandbox/action.yml
+++ b/sfcc-build/stop-sandbox/action.yml
@@ -1,0 +1,24 @@
+name: 'stop-sandbox'
+description: 'Stops sandbox'
+author: 'Seidor'
+inputs:
+  SANDBOX_ID:
+    description: 'Sandbox ID'
+    required: true
+  SFCC_TOKEN:
+    description: 'Token used for authentication in api calls'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: 'stop-sandbox'
+      shell: bash -e {0}
+      run: |
+        curl --location "https://admin.dx.commercecloud.salesforce.com/api/v1/sandboxes/${{ inputs.SANDBOX_ID }}/operations" \
+        --header "Accept: application/json" \
+        --header "Content-Type: application/json" \
+        --header "Authorization: Bearer ${{ inputs.SFCC_TOKEN }}" \
+        --data '{
+        "operation": "stop"
+        }'

--- a/sfcc-build/upload-and-activate/action.yml
+++ b/sfcc-build/upload-and-activate/action.yml
@@ -4,19 +4,16 @@ author: 'Seidor'
 inputs:
   ENVIRONMENT:
     description: 'Environment'
-    default: 'staging'
+    required: true
   INSTANCE_URL:
     description: 'Instance URL'
     required: true
   CERT_FILE:
     description: 'Path to your certificate file'
-    required: true
   CERT_INSTANCE_URL:
     description: 'URL for cert instance'
-    required: true
   CERTIFICATE_PASSWORD:
     description: 'Secret for the certificate'
-    required: true
   TOOLS_FOLDER:
     description: 'Path to your salesforce tools folder'
     required: true
@@ -33,7 +30,11 @@ runs:
     - name: 'Upload and activate code version'
       shell: bash -el {0}
       run: |
+        TOOLS_FOLDER="$GITHUB_WORKSPACE/${{ inputs.TOOLS_FOLDER }}"
+        CERT_FILE="$GITHUB_WORKSPACE/${{ inputs.CERT_FILE }}"
         ENV_URL=$([ "${{ inputs.ENVIRONMENT }}" = "staging" ] && echo "${{ inputs.CERT_INSTANCE_URL }}" || echo "${{ inputs.INSTANCE_URL }}")
-        CERT_PARAMS=$([ "${{ inputs.ENVIRONMENT }}" = "staging" ] && echo "-c \"${{ inputs.CERT_FILE }}\" -p "${{ inputs.CERTIFICATE_PASSWORD }}"" || echo "")
+        CERT_PARAMS=$([ "${{ inputs.ENVIRONMENT }}" = "staging" ] && echo "-c \"$CERT_FILE\" -p "${{ inputs.CERTIFICATE_PASSWORD }}"" || echo "")
         ACTIVATE_FLAG=$([ "${{ inputs.ACTIVATE }}" = "true" ] && echo "-a" || echo "")
-        node "${{ inputs.TOOLS_FOLDER }}/node_modules/sfcc-ci/cli.js" "code:deploy" "./${{ inputs.BUILD_NUMBER }}.zip" -i $ENV_URL $CERT_PARAMS $ACTIVATE_FLAG
+        
+        #node "$TOOLS_FOLDER/node_modules/sfcc-ci/cli.js" "code:deploy" "./${{ inputs.BUILD_NUMBER }}.zip\" -i $ENV_URL $CERT_PARAMS $ACTIVATE_FLAG
+        echo "node \"$TOOLS_FOLDER/node_modules/sfcc-ci/cli.js\" \"code:deploy\" \"./${{ inputs.BUILD_NUMBER }}.zip\" -i $ENV_URL $CERT_PARAMS $ACTIVATE_FLAG"

--- a/sfcc-build/upload-and-activate/action.yml
+++ b/sfcc-build/upload-and-activate/action.yml
@@ -37,4 +37,3 @@ runs:
         ACTIVATE_FLAG=$([ "${{ inputs.ACTIVATE }}" = "true" ] && echo "-a" || echo "")
         
         node "$TOOLS_FOLDER/node_modules/sfcc-ci/cli.js" "code:deploy" "./${{ inputs.BUILD_NUMBER }}.zip\" -i $ENV_URL $CERT_PARAMS $ACTIVATE_FLAG
-        #echo "node \"$TOOLS_FOLDER/node_modules/sfcc-ci/cli.js\" \"code:deploy\" \"./${{ inputs.BUILD_NUMBER }}.zip\" -i $ENV_URL $CERT_PARAMS $ACTIVATE_FLAG"

--- a/sfcc-build/upload-and-activate/action.yml
+++ b/sfcc-build/upload-and-activate/action.yml
@@ -36,5 +36,5 @@ runs:
         CERT_PARAMS=$([ "${{ inputs.ENVIRONMENT }}" = "staging" ] && echo "-c \"$CERT_FILE\" -p "${{ inputs.CERTIFICATE_PASSWORD }}"" || echo "")
         ACTIVATE_FLAG=$([ "${{ inputs.ACTIVATE }}" = "true" ] && echo "-a" || echo "")
         
-        #node "$TOOLS_FOLDER/node_modules/sfcc-ci/cli.js" "code:deploy" "./${{ inputs.BUILD_NUMBER }}.zip\" -i $ENV_URL $CERT_PARAMS $ACTIVATE_FLAG
-        echo "node \"$TOOLS_FOLDER/node_modules/sfcc-ci/cli.js\" \"code:deploy\" \"./${{ inputs.BUILD_NUMBER }}.zip\" -i $ENV_URL $CERT_PARAMS $ACTIVATE_FLAG"
+        node "$TOOLS_FOLDER/node_modules/sfcc-ci/cli.js" "code:deploy" "./${{ inputs.BUILD_NUMBER }}.zip\" -i $ENV_URL $CERT_PARAMS $ACTIVATE_FLAG
+        #echo "node \"$TOOLS_FOLDER/node_modules/sfcc-ci/cli.js\" \"code:deploy\" \"./${{ inputs.BUILD_NUMBER }}.zip\" -i $ENV_URL $CERT_PARAMS $ACTIVATE_FLAG"

--- a/sfcc-build/zip-and-import/action.yml
+++ b/sfcc-build/zip-and-import/action.yml
@@ -8,8 +8,8 @@ runs:
     - name: 'ZIP and import metadata'
       shell: bash -el {0}
       run: |
-        #zip -qq -r metadata.zip metadata
-        #sfcc-ci instance:upload metadata.zip
-        #sfcc-ci instance:import metadata.zip -s -f
+        zip -qq -r metadata.zip metadata
+        sfcc-ci instance:upload metadata.zip
+        sfcc-ci instance:import metadata.zip -s -f
         
-        echo "zip -qq -r metadata.zip metadata sfcc-ci instance:upload metadata.zip sfcc-ci instance:import metadata.zip -s -f"
+        #echo "zip -qq -r metadata.zip metadata sfcc-ci instance:upload metadata.zip sfcc-ci instance:import metadata.zip -s -f"

--- a/sfcc-build/zip-and-import/action.yml
+++ b/sfcc-build/zip-and-import/action.yml
@@ -8,8 +8,9 @@ runs:
     - name: 'ZIP and import metadata'
       shell: bash -el {0}
       run: |
+        echo "Zipping metadata..."
         zip -qq -r metadata.zip metadata
+        echo "Uploading and importing metadata..."
         sfcc-ci instance:upload metadata.zip
         sfcc-ci instance:import metadata.zip -s -f
-        
-        #echo "zip -qq -r metadata.zip metadata sfcc-ci instance:upload metadata.zip sfcc-ci instance:import metadata.zip -s -f"
+        echo "Metadata imported"

--- a/sfcc-build/zip-and-import/action.yml
+++ b/sfcc-build/zip-and-import/action.yml
@@ -8,6 +8,8 @@ runs:
     - name: 'ZIP and import metadata'
       shell: bash -el {0}
       run: |
-        zip -qq -r metadata.zip metadata
-        sfcc-ci instance:upload metadata.zip
-        sfcc-ci instance:import metadata.zip -s -f
+        #zip -qq -r metadata.zip metadata
+        #sfcc-ci instance:upload metadata.zip
+        #sfcc-ci instance:import metadata.zip -s -f
+        
+        echo "zip -qq -r metadata.zip metadata sfcc-ci instance:upload metadata.zip sfcc-ci instance:import metadata.zip -s -f"


### PR DESCRIPTION
Sandbox actions added (including one for stopping just in case of future needs)
Other changes include:
 - Token as output
 - Paths now include "$GITHUB_WORKSPACE/" to make sure folders are referenced correctly
 - The action used to upload the code has minor modifications in its input requirements